### PR TITLE
カリキュラム08_6にてブログ投稿一覧画面から論理削除を実行する削除ボタンを実装しました

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -36,5 +36,10 @@ class PostController extends Controller
         $post->fill($input_post)->save();
         return redirect('/posts/' . $post->id);
     }
+    public function delete(Post $post)
+    {
+        $post->delete();
+        return redirect('/');
+    }
 }
 ?>

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -4,9 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
+    use SoftDeletes;
     protected $fillable = [
         'title',
         'body',

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -15,6 +15,11 @@
                         <a href="/posts/{{ $post->id }}">{{ $post->title }}</a>
                     </h2>
                     <p class='body'>{{ $post->body }}</p>
+                    <form action="/posts/{{ $post->id }}" id="form_{{ $post->id }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button type="button" onclick="deletePost({{ $post->id }})">delete</button>
+                    </form>
                 </div>
             @endforeach
         </div>
@@ -22,5 +27,14 @@
         <div class='paginate'>
             {{ $posts->links() }}
         </div>
+        <script>
+            function deletePost(id) {
+                'use strict'
+                if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                    document.getElementById(`form_${id}`).submit();
+                }
+            }
+        </script>
+        `form_${id}`
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,3 +23,4 @@ Route::post('/posts', [PostController::class , 'store']);
 Route::get('/posts/{post}', [PostController::class ,'show']);
 Route::get('/posts/{post}/edit', [PostController::class , 'edit']);
 Route::put('/posts/{post}', [PostController::class , 'update']);
+Route::delete('/posts/{post}', [PostController::class , 'delete']);


### PR DESCRIPTION
ブログ投稿一覧画面からブログの削除ができるよう実装しました。index.blade.phpのviewファイルにDELETEメソッドのコードやJavaScriptのコードを追加し、さらに、DELETEリクエストに対応するルーティングと、delete関数を使えるようコントローラー実装とモデルクラスの修正を行いました。

ユーザーがブログの削除をできるようにするために、実装しました。
